### PR TITLE
Add a section to the name module docs with info about name restrictions.

### DIFF
--- a/docs/modules/name-module.md
+++ b/docs/modules/name-module.md
@@ -41,7 +41,7 @@ Name records are normalized before being processed for creation or query.  Each 
 HYPHEN-MINUS
 Unicode: U+002D, UTF-8: 2D
 ```
-4. Each component of the name is subject to a length of 2 to 32 characters (inclusive). These limits are configurable in the module parameters.
+4. Each component of the name is restricted to a length of 2 to 32 characters (inclusive). These limits are configurable in the module parameters.
 5. A maximum of 16 components for a name (levels in the heirarchy) is also enforced and configurable in the module parameters.
 6. Leading and trailing spaces are always trimmed off of names for consistency during processing and evaluation.
 


### PR DESCRIPTION
Updates the name module page to include info about what is and isn't allowed in names.

This is copied from the `x/name/spec/01_concepts.md` page in the provenance repo.