### PR TITLE
Update testnet and mainnet seed nodes

### DIFF
--- a/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/index.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/index.md
@@ -32,7 +32,7 @@ make install
 provenanced -t init choose-a-moniker --chain-id pio-testnet-1
 curl https://raw.githubusercontent.com/provenance-io/testnet/main/pio-testnet-1/genesis.json > genesis.json
 mv genesis.json $PIO_HOME/config
-provenanced start --testnet --p2p.seeds 2de841ce706e9b8cdff9af4f137e52a4de0a85b2@104.196.26.176:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@34.71.242.51:26656 --x-crisis-skip-assert-invariants
+provenanced start --testnet --p2p.seeds 4403e0e55fa4e43a454c4bf7922c8a93a51fb12d@seed.test.provenance.io:26656 --x-crisis-skip-assert-invariants
 ```
 
 > Note that initially, a Provenance Blockchain node may take about 1-2 hours to start up as it has to sync up with all the old transactions on the blockchain. During startup, the `provenanced` daemon will output state sync information such as:
@@ -298,7 +298,7 @@ ln -sf $PIO_HOME/cosmovisor/genesis/bin/provenanced $(which provenanced)
 Once `cosmovisor` has been installed and configured, it effectively wraps up the `provenanced` daemon process. To start the Provenanced node, use the following `cosmovisor` process.
 
 ```bash
-cosmovisor start --testnet --home $PIO_HOME --p2p.seeds 2de841ce706e9b8cdff9af4f137e52a4de0a85b2@104.196.26.176:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@34.71.242.51:26656 --x-crisis-skip-assert-invariants
+cosmovisor start --testnet --home $PIO_HOME --p2p.seeds 4403e0e55fa4e43a454c4bf7922c8a93a51fb12d@seed.test.provenance.io:26656 --x-crisis-skip-assert-invariants
 ```
 
 A node process should now be running in the foreground. It is an exercise for the reader to integrate the `provenanced` (again, wrapped by `cosmovisor`) with a service manager like `systemd` or `launchd`.

--- a/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/running-a-testnet-node-from-quicksync.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/running-a-testnet-node-from-quicksync.md
@@ -38,5 +38,5 @@ Step 4:Change config.toml to have the db-backend set to `cleveldb`
 #   - EXPERIMENTAL
 #   - use badgerdb build tag (go build -tags badgerdb)
 db_backend = "cleveldb```
-Step 6: provenanced start --testnet --p2p.seeds 2de841ce706e9b8cdff9af4f137e52a4de0a85b2@104.196.26.176:26656,add1d50d00c8ff79a6f7b9873cc0d9d20622614e@34.71.242.51:26656 --x-crisis-skip-assert-invariants
+Step 6: provenanced start --testnet --p2p.seeds 4403e0e55fa4e43a454c4bf7922c8a93a51fb12d@seed.test.provenance.io:26656 --x-crisis-skip-assert-invariants
 ````

--- a/docs/pb/blockchain/running-a-node/running-a-node-1/running-a-mainnet-node.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/running-a-mainnet-node.md
@@ -17,7 +17,7 @@ export PIO_HOME=~/.provenanced // or directory of your choosing.
 provenanced init choose-a-moniker --chain-id pio-mainnet-1
 curl https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json> genesis.json
 mv genesis.json $PIO_HOME/config
-Step 4:Change config.toml to have the db-backend set to `cleveldb` 
+Step 4:Change config.toml to have the db-backend set to `cleveldb`
 ```# Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
 # * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 #   - pure go
@@ -38,5 +38,5 @@ Step 4:Change config.toml to have the db-backend set to `cleveldb`
 #   - EXPERIMENTAL
 #   - use badgerdb build tag (go build -tags badgerdb)
 db_backend = "cleveldb```
-Step 5: provenanced start --p2p.seeds 4bd2fb0ae5a123f1db325960836004f980ee09b4@seed-0.provenance.io:26656, 048b991204d7aac7209229cbe457f622eed96e5d@seed-1.provenance.io:26656 --x-crisis-skip-assert-invariants
+Step 5: provenanced start --p2p.seeds 40f9493fa7ab4259159240e9a8ba12f90743079b@seed.provenance.io:26656 --x-crisis-skip-assert-invariants
 ````


### PR DESCRIPTION
A variant of this has been raised in #69 - however; the foundation
has advised me following the migration to tenderseed, these are the
seed nodes we should be using moving forward.
