### PR TITLE
Update documentation to reflect the steps required  to set up a node

### DIFF
--- a/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/index.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/index.md
@@ -19,14 +19,14 @@ While using the quick-start method provides a quick and easy way to start a test
 Use the following to start up a Provenance Blockchain node in the foreground.
 
 :::info
-Refer to [https://github.com/provenance-io/testnet](https://github.com/provenance-io/testnet) for the latest testnet version. As of this writing, it is `0.2.0` as reflected in the version tags below.
+Refer to [https://github.com/provenance-io/testnet](https://github.com/provenance-io/testnet) for the latest testnet version. As of this writing, it is `1.16.0` as reflected in the version tags below.
 :::
 
 ```
 export PIO_HOME=~/.provenanced
 git clone https://github.com/provenance-io/provenance.git
 cd provenance
-git checkout tags/v0.2.0 -b v0.2.0
+git checkout tags/v1.16.0 -b v1.16.0
 make clean
 make install
 provenanced -t init choose-a-moniker --chain-id pio-testnet-1
@@ -54,7 +54,7 @@ Unlike the Quick Start instructions, this section describes setting up a new ful
 Before starting this section, be sure the prerequisites have been installed as described in [Installing Provenance Blockchain](../../#prerequisites).
 
 :::info
-See the [testnet repo](https://github.com/provenance-io/testnet) for the latest genesis/config files and version information. The node started in this section is chain id `pio-testnet-1` Provenance Blockchain release 0.2.0 ([https://github.com/provenance-io/provenance/releases/tag/v0.2.0](https://github.com/provenance-io/provenance/releases/tag/v0.2.0))
+See the [testnet repo](https://github.com/provenance-io/testnet) for the latest genesis/config files and version information. The node started in this section is chain id `pio-testnet-1` Provenance Blockchain release 1.16.0 ([https://github.com/provenance-io/provenance/releases/tag/v1.16.0](https://github.com/provenance-io/provenance/releases/tag/v1.16.0))
 :::
 
 ### Cleaning up Existing testnet Node
@@ -69,10 +69,10 @@ mkdir -p $PIO_HOME/config
 
 ### Download and Install Provenance Blockchain
 
-Use `git` to download the latest testnet version of Provenance Blockchain (`0.2.0` as of this writing):
+Use `git` to download the latest testnet version of Provenance Blockchain (`1.16.0` as of this writing):
 
 ```bash
-git clone -b v0.2.0 https://github.com/provenance-io/provenance.git
+git clone -b v1.16.0 https://github.com/provenance-io/provenance.git
 cd provenance
 ```
 
@@ -90,7 +90,7 @@ provenanced version --long
 
 name: Provenance Blockchain
 server_name: provenanced
-version: 0.2.0
+version: 1.16.0
 commit: 75fef3a701af3787a56d4c8c6b40f67b95b79eb6
 build_tags: netgo,gcc,cleveldb,ledger
 go: go version go1.15.5 darwin/amd64

--- a/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/running-a-testnet-node-from-quicksync.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/running-a-testnet-node-from-quicksync.md
@@ -4,7 +4,9 @@ import { DocSubheader } from '/docs/components/DocSubheader';
 
 <DocSubheader text="Running a testnet node for pio-testnet-1 from a quicksync file." />
 
-The steps for running testnet are exactly the same as mainnet except that the github repo is here https://github.com/provenance-io/testnet and the chain id is `pio-testnet-1`
+The steps for running testnet are for the most part the same as mainnet except that the github repo is here
+[https://github.com/provenance-io/testnet](https://github.com/provenance-io/testnet), the `-t` flag is required to
+set the key prefix from 505 to 1 (putting the binary in testnet mode)and the chain id is `pio-testnet-1`
 
 ````markup
 Step 1: download the latest quickysync via https://test.provenance.io/quicksync.

--- a/docs/pb/blockchain/running-a-node/running-a-node-1/running-a-mainnet-node.md
+++ b/docs/pb/blockchain/running-a-node/running-a-node-1/running-a-mainnet-node.md
@@ -4,39 +4,19 @@ description: running a mainnet node for pio-mainnet-1
 
 # Running a mainnet node
 
-The steps for running mainnet are exactly the same as testnet except that the github repo is here [https://github.com/provenance-io/mainnet](https://github.com/provenance-io/mainnet) and the chain id is `pio-mainnet-1`
+The steps for running mainnet are for the most part, the same as testnet except that the github repo is here
+[https://github.com/provenance-io/mainnet](https://github.com/provenance-io/mainnet) and the chain id is `pio-mainnet-1`
 
 ````markup
 Step 1:download the latest quickysync via https://provenance.io/quicksync and latest provenanced version.
-At the time of writing this document latest version on mainnet was v1.7.6.
+At the time of writing this document latest version on mainnet was v1.16.0.
 Download release from https://github.com/provenance-io/provenance/releases/
-For e.g for version v1.7.6 url is https://github.com/provenance-io/provenance/releases/tag/v1.7.6
+For e.g for version v1.16.0 url is https://github.com/provenance-io/provenance/releases/tag/v1.16.0
 Step 2:Untar data directory from the quicksync download and replacing the untarred data directory to $PIO_HOME/data
 Step 3: Run the below commands
 export PIO_HOME=~/.provenanced // or directory of your choosing.
 provenanced init choose-a-moniker --chain-id pio-mainnet-1
 curl https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json> genesis.json
 mv genesis.json $PIO_HOME/config
-Step 4:Change config.toml to have the db-backend set to `cleveldb`
-```# Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
-# * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
-#   - pure go
-#   - stable
-# * cleveldb (uses levigo wrapper)
-#   - fast
-#   - requires gcc
-#   - use cleveldb build tag (go build -tags cleveldb)
-# * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
-#   - EXPERIMENTAL
-#   - may be faster is some use-cases (random reads - indexer)
-#   - use boltdb build tag (go build -tags boltdb)
-# * rocksdb (uses github.com/tecbot/gorocksdb)
-#   - EXPERIMENTAL
-#   - requires gcc
-#   - use rocksdb build tag (go build -tags rocksdb)
-# * badgerdb (uses github.com/dgraph-io/badger)
-#   - EXPERIMENTAL
-#   - use badgerdb build tag (go build -tags badgerdb)
-db_backend = "cleveldb```
-Step 5: provenanced start --p2p.seeds 40f9493fa7ab4259159240e9a8ba12f90743079b@seed.provenance.io:26656 --x-crisis-skip-assert-invariants
+Step 4: provenanced start --p2p.seeds 40f9493fa7ab4259159240e9a8ba12f90743079b@seed.provenance.io:26656 --x-crisis-skip-assert-invariants
 ````


### PR DESCRIPTION
This commit updates the documentation to remove the use of the
cleveldb requirement, as the foundation has advised me this has been
removed following version 1.13. I've also refreshed the docs for
both mainnet and testnet to indicate that these were written under
the assumption of v1.16.0 as there were multiple version references
in these pages. I've also described the necessity of using the `-t`
flag when running a testnet node, as this can lead to undefined
behaviour if not supplied when running the testnet chain.
